### PR TITLE
add delete to ckan harvester

### DIFF
--- a/ckanext/harvest/helpers.py
+++ b/ckanext/harvest/helpers.py
@@ -82,6 +82,34 @@ def package_list_for_source(source_id):
     return out
 
 
+def all_packages_for_source(source_id):
+    '''
+    Creates a dataset list with all the ones belonging to a particular harvest
+    source.
+
+    Returns array of package dictionaries
+    '''
+    limit = 1000
+    page = 1
+    fq = '+harvest_source_id:"{0}"'.format(source_id)
+    search_dict = {
+        'fq': fq,
+        'rows': limit,
+        'sort': 'metadata_modified desc',
+        'start': (page - 1) * limit,
+    }
+
+    context = {'model': model, 'session': model.Session}
+    out = []
+    query = logic.get_action('package_search')(context, search_dict)
+
+    while query['results']:
+        out = out + query['results']
+        search_dict['start'] = search_dict['start'] + limit
+        query = logic.get_action('package_search')(context, search_dict)
+
+    return out
+
 def package_count_for_source(source_id):
     '''
     Returns the current package count for datasets associated with the given

--- a/ckanext/harvest/plugin/__init__.py
+++ b/ckanext/harvest/plugin/__init__.py
@@ -287,6 +287,7 @@ class Harvest(MixinPlugin, p.SingletonPlugin, DefaultDatasetForm, DefaultTransla
     def get_helpers(self):
         from ckanext.harvest import helpers as harvest_helpers
         return {
+                'all_packages_for_source': harvest_helpers.all_packages_for_source,
                 'package_list_for_source': harvest_helpers.package_list_for_source,
                 'package_count_for_source': harvest_helpers.package_count_for_source,
                 'harvesters_info': harvest_helpers.harvesters_info,


### PR DESCRIPTION
add a delete function to the CKAN harvester. When a remote dataset is no longer available, either because it was deleted or made private, the local dataset will be deleted. This feature requires the 'force_all' harvester config option to be set to 'true'. If 'force_all' is false or missing then datasets will not be deleted as the harvester will only gather datasets updated since the last successful harvest.

```
"force_all": true
```